### PR TITLE
bootstrapのnpm移行

### DIFF
--- a/app/assets/javascripts/Task.js
+++ b/app/assets/javascripts/Task.js
@@ -9,10 +9,10 @@ export default class Task extends React.Component {
   render() {
     return (
       <tr key={this.props.id}>
-        <td>
+        <td className={this.props.status}>
           {this.props.content}
         </td>
-        <td>
+        <td className={this.props.status}>
           <select className="form-control" defaultValue={this.props.status} onChange={this.handleUpdate.bind(this)} >
             <option value="todo" key="todo">todo</option>
             <option value="doing" key="doing">doing</option>

--- a/app/assets/stylesheets/task.css
+++ b/app/assets/stylesheets/task.css
@@ -1,0 +1,9 @@
+.todo {
+  background-color: #dc143c;
+}
+.doing {
+  background-color: #ffff00;
+}
+.done {
+  background-color: #87cefa;
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "babel-preset-react": "^6.16.0",
     "react": "^15.3.2",
+    "react-bootstrap": "^0.30.5",
     "react-dom": "^15.3.2",
     "superagent": "^2.3.0"
   },


### PR DESCRIPTION
課題５「bootstrapはCDNから読んでいるが、この管理をnpm経由にしたい。どういう方法がある？」をreact-bootstrapで実装します。

BootstrapのコンポーネントをJSXで扱えるようにしたnpmのライブラリです。

```
// インポート
import Button from 'react-bootstrap/lib/Button';

...

// bootstrapのボタン
<Button type="submit">登録</Button>
```

と記述すると、以下のタグを生成します。

```
<button type="submit" disabled=false className="btn btn-default">登録</button>
```

ただし、どうやらBootstrapのCSSは内部には含まれていないようで、
上記を使うためには、cdnなど外部からCSSを参照する必要があります。
追加課題の目的からは外れてしまうため、別の方法を検討したいと思います。
